### PR TITLE
Rename BaseError#type => BaseError#code

### DIFF
--- a/packages/error/src/error.spec.ts
+++ b/packages/error/src/error.spec.ts
@@ -7,21 +7,21 @@ describe("error", () => {
       // @ts-expect-error we are explicitly testing the error
       class TestError extends BaseError {}
 
-      expectTypeOf<TestError["type"]>().toBeString();
+      expectTypeOf<TestError["code"]>().toBeString();
     });
 
     it("should type as literal", () => {
       class TestError extends BaseError {
-        readonly type = "test";
+        readonly code = "TEST";
       }
 
-      expectTypeOf<TestError["type"]>().toEqualTypeOf<"test">();
+      expectTypeOf<TestError["code"]>().toEqualTypeOf<"TEST">();
     });
   });
 
   describe("UnknownError", () => {
     it("should type as literal", () => {
-      expectTypeOf<UnknownError["type"]>().toEqualTypeOf<"unknown">();
+      expectTypeOf<UnknownError["code"]>().toEqualTypeOf<"UNKNOWN">();
     });
 
     it("should construct a UnknownError with cause", () => {

--- a/packages/error/src/error.ts
+++ b/packages/error/src/error.ts
@@ -1,19 +1,22 @@
 /**
  * The abstract BaseError class is the root of all your error classes, It ensures
- * cause is ponyfilled and enforces the requirement for adding a `type` property.
+ * cause is ponyfilled and enforces the requirement for adding a `code` property.
  * This will be how you handle particular errors caused in your pipeline.
  *
+ * `code` is typically in SCREAMING_SNAKE_CASE. You can see
+ * [example codes from Nodejs](https://nodejs.org/api/errors.html#nodejs-error-codes).
+ *
  * @example
- * Make sure the child class sets a `readonly type` string literal property.
+ * Make sure the child class sets a `readonly code` string literal property.
  *
  * ```ts
  * class ExampleError extends BaseError {
- *   readonly type = "example";
+ *   readonly code = "EXAMPLE";
  * }
  * ```
  */
 export abstract class BaseError extends Error {
-  abstract readonly type: string;
+  abstract readonly code: string;
   /**
    * @hidden
    */
@@ -52,5 +55,5 @@ export abstract class BaseError extends Error {
  * ```
  */
 export class UnknownError extends BaseError {
-  readonly type = "unknown";
+  readonly code = "UNKNOWN";
 }

--- a/packages/result/src/result.ts
+++ b/packages/result/src/result.ts
@@ -415,14 +415,14 @@ export function fromResults<T, E>(
  * Error thrown when {@link unwrap} or {@link unwrapError} fail to unwrap the Result.
  */
 export class ResultUnwrapError extends BaseError {
-  readonly type = "result_unwrap";
+  readonly code = "RESULT_UNWRAP";
 }
 
 /**
  * Error returned when {@link fromResults} includes error states in its results.
  */
 export class AggregateResultsError<T, E> extends BaseError {
-  readonly type = "aggregate_results";
+  readonly code = "AGGREGATE_RESULTS";
 
   successes: T[];
   errors: E[];

--- a/packages/zod/src/zod.ts
+++ b/packages/zod/src/zod.ts
@@ -6,7 +6,7 @@ import { AsyncResult, error, success } from "@railway-effects/result";
  * Error returned by {@link parseWithResult}.
  */
 export class ParseError<T = unknown> extends BaseError {
-  readonly type = "parse";
+  readonly code = "PARSE";
   zod: ZodError<T>;
 
   constructor(message: string, { zod }: { zod: ZodError<T> }) {


### PR DESCRIPTION
This is more consistent with the ecosystem (specifically Nodejs), which tends to use `code` in `SCREAMING_SNAKE_CASE`, so we'll do the same here.